### PR TITLE
Fix #6: force goUSFormatSettings during JSON write

### DIFF
--- a/UnitTests/Tests/Tests.Grijjy.Bson.IO.pas
+++ b/UnitTests/Tests/Tests.Grijjy.Bson.IO.pas
@@ -2646,7 +2646,7 @@ procedure TestJsonData.WriteValueTree(const Builder: TStringBuilder;
 
   procedure WriteLine(const S: UnicodeString; const Args: array of const);
   begin
-    Builder.Append(Format(S, Args)).AppendLine;
+    Builder.Append(Format(S, Args, goUSFormatSettings)).AppendLine;
   end;
 
 var


### PR DESCRIPTION
Small glitch: ensure `goUSFormatSettings` is used during JSON write in the unit tests.

This makes the reading and writing format settings symmetric, and fixes tests in countries having a decimal comma (where the tests fail for instance because the read double `12.3` is not the same as the double written to string as `12,3`).