### PR TITLE
Fixed record deserialize of protocol buffers

### DIFF
--- a/Grijjy.ProtocolBuffers.pas
+++ b/Grijjy.ProtocolBuffers.pas
@@ -2149,9 +2149,6 @@ begin
     FInitProc(ARecord);
 
   FieldCount := Length(FFields);
-  if (FieldCount = 0) then
-    Exit;
-
   FieldIndex := 0;
   while (AReader.HasData) do
   begin


### PR DESCRIPTION
You cannot exit from deserialize even when current fields count is zero, because you need to skip the bytes received of the fields of the record (that in this case will not be found).