### PR TITLE
FIX: added try-except block on disconnection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ HtmlHelp/
 Html/
 #ignore DUnitX output
 dunitx-results.xml
+*.o

--- a/Grijjy.Bson.IO.pas
+++ b/Grijjy.Bson.IO.pas
@@ -6832,7 +6832,7 @@ var
   C: Char;
 begin
   C := ABuffer.Read;
-  if (C >= #$80) then
+  if (Ord(C) >= $80) then
     CharError(ABuffer, C, AToken)
   else
     FCharHandlers[C](ABuffer, C, AToken);
@@ -6847,7 +6847,7 @@ begin
   while (C <> #0) and (C <= ' ') do
     C := ABuffer.Read;
 
-  if (C >= #$80) then
+  if (Ord(C) >= $80) then
     CharError(ABuffer, C, AToken)
   else
     FCharHandlers[C](ABuffer, C, AToken);

--- a/Grijjy.Http.pas
+++ b/Grijjy.Http.pas
@@ -638,7 +638,7 @@ begin
       { delete buffer }
       if FSize > ALength then
       begin
-        Move(FBuffer[Size], FBuffer[0], FSize - ALength);
+        Move(FBuffer[ALength], FBuffer[0], FSize - ALength);
         FSize := FSize - ALength;
       end
       else

--- a/Grijjy.ProtocolBuffers.pas
+++ b/Grijjy.ProtocolBuffers.pas
@@ -2149,9 +2149,6 @@ begin
     FInitProc(ARecord);
 
   FieldCount := Length(FFields);
-  if (FieldCount = 0) then
-    Exit;
-
   FieldIndex := 0;
   while (AReader.HasData) do
   begin

--- a/Grijjy.ProtocolBuffers.pas
+++ b/Grijjy.ProtocolBuffers.pas
@@ -1086,12 +1086,14 @@ begin
   Len := AReader.ReadVarUInt;
   SetLength(RecBytes, Len);
   if (Len > 0) then
+  begin
     AReader.ReadBytes(RecBytes[0], Len);
-  RecReader := TReader.Create(@RecBytes[0], Len);
-  try
-    Info.Deserialize(RecReader, P);
-  finally
-    RecReader.Free;
+    RecReader := TReader.Create(@RecBytes[0], Len);
+    try
+      Info.Deserialize(RecReader, P);
+    finally
+      RecReader.Free;
+    end;
   end;
 end;
 

--- a/Grijjy.SocketPool.Linux.pas
+++ b/Grijjy.SocketPool.Linux.pas
@@ -710,7 +710,7 @@ var
   Close: Boolean;
   Error: Integer;
 begin
-  while True do
+  while Terminated = false do
   begin
     NumberOfEvents := epoll_pwait(FOwner.Handle, @FEvents, MAX_EVENTS, 100, nil);
     if NumberOfEvents = 0 then { timeout }

--- a/Grijjy.SocketPool.Win.pas
+++ b/Grijjy.SocketPool.Win.pas
@@ -996,7 +996,7 @@ begin
   {$IFDEF DEBUG}
   NameThreadForDebugging('TSocketPoolWorker');
   {$ENDIF}
-  while True do
+  while Terminated = false do
   begin
     ReturnValue := GetQueuedCompletionStatus(FOwner.FHandle, BytesTransferred,
       ULONG_PTR(Connection), POverlapped(PerIoData), WSA_INFINITE);

--- a/Grijjy.System.Console.pas
+++ b/Grijjy.System.Console.pas
@@ -1,0 +1,90 @@
+unit Grijjy.System.Console;
+
+{$INCLUDE 'Grijjy.inc'}
+
+interface
+
+uses
+  {$IFDEF LINUX}
+  Posix.Signal,
+  {$ENDIF}
+  {$IFDEF MSWINDOWS}
+  Windows,
+  {$ENDIF}
+  System.SysUtils,
+  System.SyncObjs;
+
+function WaitForCtrlC(const ATimeout: Cardinal = INFINITE): Boolean;
+
+var
+  CtrlC: Boolean = False;
+
+implementation
+
+var
+  CtrlC_Event: TEvent;
+
+{$IFDEF MSWINDOWS}
+function ConsoleCtrlHandler(dwCtrlType: DWORD): BOOL; stdcall;
+begin
+  if (dwCtrlType = CTRL_C_EVENT) then
+  begin
+    CtrlC_Event.SetEvent;
+    CtrlC := True;
+  end;
+  Result := True;
+end;
+{$ENDIF}
+
+{$IFDEF LINUX}
+var
+  sigIntHandler: sigaction_t;
+
+procedure SigHandler(SigNum: Integer); cdecl;
+begin
+  CtrlC_Event.SetEvent;
+end;
+{$ENDIF}
+
+function WaitForCtrlC(const ATimeout: Cardinal): Boolean;
+begin
+  Result := (CtrlC_Event.WaitFor(ATimeout) = TWaitResult.wrTimeout);
+end;
+
+{$IFDEF MSWINDOWS}
+procedure DisableQuickEdit;
+const
+  ENABLE_QUICK_EDIT = $40;
+  ENABLE_EXTENDED_FLAGS = $80;
+var
+  StdHandle: THandle;
+  Mode: UInt32;
+begin
+  StdHandle := GetStdHandle(STD_INPUT_HANDLE);
+  GetConsoleMode(StdHandle, Mode);
+  Mode := Mode and not ENABLE_QUICK_EDIT;
+  Mode := Mode and not ENABLE_LINE_INPUT;
+  Mode := Mode and not ENABLE_MOUSE_INPUT;
+  Mode := Mode and not ENABLE_EXTENDED_FLAGS;
+  SetConsoleMode(StdHandle, Mode);
+end;
+{$ENDIF}
+
+initialization
+  CtrlC_Event := TEvent.Create(nil, True, False, '');
+
+  {$IFDEF MSWINDOWS}
+  Windows.SetConsoleCtrlHandler(@ConsoleCtrlHandler, True);
+  DisableQuickEdit;
+  {$ENDIF}
+  {$IFDEF LINUX}
+  sigIntHandler._u.sa_handler := @SigHandler;
+  sigemptyset(sigIntHandler.sa_mask);
+  sigIntHandler.sa_flags := 0;
+  sigaction(SIGINT, @sigIntHandler, nil);
+  {$ENDIF}
+
+finalization
+  CtrlC_Event.Free;
+
+end.


### PR DESCRIPTION
In some cases, shutdown of application result in exception. This is because DisconnectEx() function throws an exception. Most likely because of trying to disconnect an invalid socket. This is the case when trying to connect with invalid connection settings or when MongoDB is not running and closing the application within 5s afterwards. This fix does not solve the origin of the problem, but it solves application crashes on shutdown.