### PR TITLE
FIX: delete buffer inside TThreadSafeBuffer.Read

### DIFF
--- a/Grijjy.Http.pas
+++ b/Grijjy.Http.pas
@@ -638,7 +638,7 @@ begin
       { delete buffer }
       if FSize > ALength then
       begin
-        Move(FBuffer[Size], FBuffer[0], FSize - ALength);
+        Move(FBuffer[ALength], FBuffer[0], FSize - ALength);
         FSize := FSize - ALength;
       end
       else


### PR DESCRIPTION
In Line 641
```
Move(FBuffer[Size], FBuffer[0], FSize - ALength);
```
changed to:
```
Move(FBuffer[ALength], FBuffer[0], FSize - ALength);
```