### PR TITLE
(ProtocolBuffers) Do not use packed arrays for repeated enumerations

### DIFF
--- a/Grijjy.ProtocolBuffers.pas
+++ b/Grijjy.ProtocolBuffers.pas
@@ -1299,7 +1299,7 @@ begin
           ASerializeProc := SerializeBytes;
           ADeserializeProc := DeserializeBytes;
         end
-        else if (ArrayInfo.ElementType.Kind in [tkInteger, tkFloat, tkEnumeration, tkInt64]) then
+        else if (ArrayInfo.ElementType.Kind in [tkInteger, tkFloat, tkInt64]) then
         begin
           { Use "packed" arrays for 32-bit and 64-bit types }
           ASerializeProc := SerializeDynArrayPacked;


### PR DESCRIPTION
As per the [protobuf3 specification](https://protobuf.dev/programming-guides/encoding/#packed), only scalar types (integer etc.) must use packed format arrays, while enums must always use unpacked repeated format. 

> Repeated enums may be packable at some point, but they currently are not.

Grijjy.ProtocolBuffers.pas currently assumes packet format also for enumerations, which leads to errors during deserialization. See test case below.

This PR changes the code so that packed format is only used for `tkInteger`, `tkFloat` and `tkInt64`, but no longer for `tkEnumeration`.

Test case that failed before:

````delphi
type
  TColorMode = (
    ColorMode0,
    ColorMode1,
    ColorMode2,
    ColorMode3,
    ColorMode4,
    ColorMode5,
    ColorMode6,
    ColorMode7,
    ColorMode8,
    ColorMode9,
    ColorMode10,
    ColorMode11,
    ColorMode12,
    ColorMode13,
    ColorMode14,
    ColorMode15,
    ColorMode16,
    ColorMode17,
    ColorMode18,
    ColorMode19,
    ColorMode20,
    ColorMode21,
    ColorMode22,
    ColorMode23,
    ColorMode24,
    ColorMode25,
    ColorMode26,
    ColorMode27,
    ColorMode28,
    ColorMode29,
    ColorMode30,
    ColorMode31,
    ColorMode32,
    ColorMode33,
    ColorMode34,
    ColorMode35,
    ColorMode36,
    ColorMode37,
    ColorMode38,
    ColorMode39,
    ColorMode40,
    ColorMode41,
    ColorMode42,
    ColorMode43,
    ColorMode44,
    ColorMode45,
    ColorMode46,
    ColorMode47,
    ColorMode48,
    ColorMode49,
    ColorMode50,
    ColorMode51
  );

  TListEntitiesLightResponse = record
    [Serialize(1)] object_id: string;
    [Serialize(2)] key: fixedint32;
    [Serialize(3)] name: string;
    [Serialize(4)] unique_id: string;
    [Serialize(12)] supported_color_modes: TArray<TColorMode>;

    [Serialize(5)] legacy_supports_brightness: boolean;
    [Serialize(6)] legacy_supports_rgb: boolean;
    [Serialize(7)] legacy_supports_white_value: boolean;
    [Serialize(8)] legacy_supports_color_temperature: boolean;

    [Serialize(9)] min_mireds: single;
    [Serialize(10)] max_mireds: single;
    [Serialize(11)] effects: TArray<string>;
    [Serialize(13)] disabled_by_default: boolean;
    [Serialize(14)] icon: string;
  end;
````

Test data:

    0A0372676215B2CF72381A03524742221166697273746E6F64656C69676874726762602328013001

We have a single value "35" for field 12 here; without the changes of this PR, the decoder assumes this to be the length of a packed array, and tries to read past the end of the buffer, leading to an "unexpected end of protocol buffer" error.