### PR TITLE
FIX: Size check to avoid range-check-exception

### DIFF
--- a/Grijjy.Bson.IO.pas
+++ b/Grijjy.Bson.IO.pas
@@ -2657,8 +2657,11 @@ begin
     until (FCapacity >= (FSize + ASize));
     SetLength(FBuffer, FCapacity);
   end;
-  Move(AValue, FBuffer[FSize], ASize);
-  Inc(FSize, ASize);
+  if (ASize > 0) then
+  begin
+    Move(AValue, FBuffer[FSize], ASize);
+    Inc(FSize, ASize);
+  end;
 end;
 
 procedure TgoBsonWriter.TOutput.WriteBinarySubType(
@@ -3468,8 +3471,11 @@ begin
     until (FCapacity >= (FSize + ASize));
     ReallocMem(FBuffer, FCapacity);
   end;
-  Move(AValue, FBuffer[FSize], ASize);
-  Inc(FSize, ASize);
+  if (ASize > 0) then
+  begin
+    Move(AValue, FBuffer[FSize], ASize);
+    Inc(FSize, ASize);
+  end;
 end;
 
 procedure TgoJsonWriter.TOutput.Append(const AValue: Char);


### PR DESCRIPTION
Hi Eric,
at some point, when trying to write empty string with the TgoBsonWriter, there is a range-check-exception (obviously only if range-check is active in compiler settings).
In my case, when entering the function, I had the following szenario:
- passed ASize=0 (empty string)
- FCapacity=512
- FSize=512
So we're exactly at the buffer border. But since ASize=0, the comparison
`  if ((FSize + ASize) > FCapacity) then
`
is not true and FCapacity does not get doubled. Therefore Move(AValue, FBuffer[FSize], ASize); will result in a range-check-exception. Changing the above line to 
`  if ((FSize + ASize) >= FCapacity) then
`
would solve the problem, too, but since we didn't want to write anything (empty string, ASize=0), neither Move() not Inc() does make any sense. This is why I think checking for ASize > 0 is the better fix.
Thanks and best regards
  Michael