### PR TITLE
Date time and null strings fix

### DIFF
--- a/Grijjy.Bson.Serialization.pas
+++ b/Grijjy.Bson.Serialization.pas
@@ -2141,6 +2141,12 @@ class function TgoBsonSerializer.DeserializeString(const AInfo: TInfo;
   const AReader: IgoBsonBaseReader): String;
 begin
   case AReader.GetCurrentBsonType of
+    // do not be so strict with the type casts. We can cast a int to a string - no problems.
+    TgoBsonType.Int32:
+      Exit(AReader.ReadInt32.ToString);
+    TgoBsonType.Int64:
+      Exit(AReader.ReadInt64.ToString);
+
     TgoBsonType.String:
       Exit(AReader.ReadString);
 

--- a/Grijjy.Bson.Serialization.pas
+++ b/Grijjy.Bson.Serialization.pas
@@ -1909,6 +1909,7 @@ class function TgoBsonSerializer.DeserializeDateTime(const AInfo: TInfo;
 var
   DT: TgoBsonDateTime;
   Name: String;
+  lDateStr: String;
 begin
   case AReader.GetCurrentBsonType of
     TgoBsonType.DateTime:
@@ -1937,7 +1938,13 @@ begin
       Result := goDateTimeFromTicks(AReader.ReadInt64, True);
 
     TgoBsonType.String:
-      Result := ISO8601ToDate(AReader.ReadString, True);
+    begin
+      // the ISO8601ToDate() requires a "T" to separate the date part from the time part
+      lDateStr:= AReader.ReadString;
+      if Copy(lDateStr, 11, 1) = ' ' then
+        lDateStr[11]:= 'T';
+      Result := ISO8601ToDate(lDateStr, True);
+    end;
   else
     raise EgoBsonSerializerError.Create('Unsupported TDateTime deserialization type');
   end;

--- a/Grijjy.Bson.pas
+++ b/Grijjy.Bson.pas
@@ -9420,7 +9420,8 @@ end;
 
 function TValueNull.ToString(const ADefault: String): String;
 begin
-  Result := 'null';
+  // if a string value is empty, or not present, rather return '' instead of 'null'
+  Result := '';
 end;
 
 { TValueUndefined }


### PR DESCRIPTION
I implemented the following changes, you might be interested in:

* Grijjy.Bson.Serialization.pas
TgoBsonSerializer.DeserializeString(): do not be so strict with the type casts. We can cast a int to a string - no problems.
  this can happen if the REST endpoint changed a field from string to integer, but the delphi class/record did not reflect those changes.

* Grijjy.Bson.pas:
  TValueNull.ToString
  returns '' instead of 'null' - which is the more delphi way to handle missing fields and empty strings. besides, it could be confused with the string having a content of "null"
  
* Grijjy.Bson.Serialization.pas:
  the ISO8601ToDate() requires a "T" to separate the date part from the time part
